### PR TITLE
Manage fetch_all parameter and fix ak freeze

### DIFF
--- a/ak/ak_build.py
+++ b/ak/ak_build.py
@@ -81,12 +81,15 @@ class AkBuild(AkSub):
                 raise Exception(
                     'Src must be in the format '
                     'http://github.com/oca/server-tools 10.0 <optional sha>')
-            return {
+            repo_dict= {
                 'remotes': {'origin': src},
                 'merges': ['origin %s' % (commit or branch)],
                 'target': 'origin %s' % branch,
                 'default': {'depth': repo.get('depth', DEFAULT_DEPTH)},
             }
+            if commit:
+                repo_dict['fetch_all'] = ['origin']
+            return repo_dict
 
     def _generate_repo_yaml(self, config):
         repo_conf = {}
@@ -211,7 +214,12 @@ class AkFreeze(AkSub):
 
     def find_branch_last_commit(self, remote, repo, branch):
         with local.cwd(repo):
-            sha = git['rev-parse'][remote + '/' + branch]().strip()
+            try:
+                # We do not freeze this kind of refs for now :
+                # refs/pull/780/head
+                sha = git['rev-parse'][remote + '/' + branch]().strip()
+            except ProcessExecutionError:
+                sha = ''
         return sha
 
     def main(self, *args):
@@ -229,16 +237,31 @@ class AkFreeze(AkSub):
         for directory, repo_data in conf.items():
             i = 0
             for merge in repo_data.get('merges'):
-                parts = merge.split(' ')
-                # branch is already frozen with commit
-                if is_sha1(parts[1]):
-                    i += 1
-                    continue
+                if isinstance(merge, str):
+                    parts = merge.split(' ')
+                    # branch is already frozen with commit
+                    if is_sha1(parts[1]):
+                        i += 1
+                        continue
+                    else:
+                        sha = self.find_branch_last_commit(
+                            parts[0], directory, parts[1])
+                        if not sha:
+                            continue
+                        parts[1] = sha
+                        repo_data.get('merges')[i] = ' '.join(parts)
+                        i += 1
                 else:
-                    sha = self.find_branch_last_commit(parts[0],
-                                                       directory, parts[1])
-                    parts[1] = sha
-                    repo_data.get('merges')[i] = ' '.join(parts)
-                    i -= 1
+                    if is_sha1(merge.get('ref', '')):
+                        continue
+                    else:
+                        sha = self.find_branch_last_commit(
+                            merge.get('remote'), directory, merge.get('ref'))
+                        if not sha:
+                            continue
+                        merge['ref'] = sha
+            # Since we freeze every merges, we should always fetch all remotes
+            remotes = list(repo_data.get('remotes').keys())
+            repo_data['fetch_all'] = remotes
         with open(self.output, 'w') as outfile:
             yaml.dump(conf, outfile, default_flow_style=False)


### PR DESCRIPTION
When we specify a commit in our spec file, like this : 
```
bank_payment:
    modules: []
    src: https://github.com/OCA/bank-payment 8.0 9dc92beb4c2f07dbf189487875f0405385cb762e
```
we need to declare also the `fetch_all` parameter.
Without it, gitaggregator will try to fetch the commit and fail.

The second problem resoved by this PR is that the ak freeze was not working in some cases.
For instance, with the more complex merges syntact, it was failing : 
```
    merges:
        -
            remote: oca
            ref: 63903204785bd8c411fa65d7feec3ce2e8e7171c
            depth: false
```

Last change, we avoid to crash is the ref specified in the merges info is not a commit or a branch.
Like if we specify : `ref: refs/pull/780/head`, it would fail.
Now, it will just ignore it (but it won't freeze either in this case, it does not seems very necessary nor easy)

@sebastienbeau @bealdav @hparfr 