### PR TITLE
Print addons path as absolute path instead of relative

### DIFF
--- a/ak/ak_build.py
+++ b/ak/ak_build.py
@@ -143,8 +143,6 @@ class AkBuild(AkSub):
                     # When odoo, we need to add 2 path
                     paths.append('%s/odoo/addons' % ODOO_FOLDER)
                     paths.append('%s/addons' % ODOO_FOLDER)
-                # Is it still really needed? why would we use relative path
-                # with C2C docker image? I think it should be removed
                 elif repo_path[0:2] == './':
                     relative_paths.append(repo_path)
                 else:
@@ -152,14 +150,11 @@ class AkBuild(AkSub):
                     # Update 2019/04 No it should not?
                     paths.append('%s/%s' % (VENDOR_FOLDER, repo_path))
 
-        # Construct absolute path, then relative path if any and merge both
-        # AFAIK the relative path logic should be removed.
-        # Because we do not use it and it add complexity
-        addons_path = '{}{}'.format(PREFIX, ',{}'.format(PREFIX).join(paths))
-        relative_path = ','.join(relative_paths)
-        whole_path = '{},{}'.format(addons_path, relative_path)
-        print('Addons path for your config file: ', whole_path)
-        return whole_path
+        addons_path = ','.join(paths + relative_paths)
+        # Construct absolute path, better for odoo config file.
+        abs_path = ",".join([PREFIX + repo_path for repo_path in paths])
+        print('Addons path for your config file: ', abs_path)
+        return addons_path
 
     def _ensure_viable_installation(self, config):
         if not local.path(config).is_file():

--- a/ak/ak_build.py
+++ b/ak/ak_build.py
@@ -211,11 +211,9 @@ class AkBuild(AkSub):
                     # Update 2019/04 No it should not?
                     paths.append('%s/%s' % (VENDOR_FOLDER, repo_path))
 
-        addons_path = ','.join(paths + relative_paths)
         # Construct absolute path, better for odoo config file.
         abs_path = ",".join([PREFIX + repo_path for repo_path in paths])
         print('Addons path for your config file: ', abs_path)
-        return addons_path
 
     def _ensure_viable_installation(self, config):
         if not local.path(config).is_file():

--- a/ak/ak_sub.py
+++ b/ak/ak_sub.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 
 ERP_CFG = local.env.get('ERP_CFG_PATH', 'odoo.cfg')
 WORKSPACE = '.'

--- a/ak/ak_sub.py
+++ b/ak/ak_sub.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
-__version__ = "2.0.5"
+__version__ = "2.0.8"
 
 ERP_CFG = local.env.get('ERP_CFG_PATH', 'odoo.cfg')
 WORKSPACE = '.'


### PR DESCRIPTION
@bealdav @sebastienbeau @hparfr @bguillot 

Because it is so annoying it does not work that way...
I did not really understand the logic with './' in spec.yaml.
I did try to keep the previous logic, even if I think it is outdated. And I believe it should be removed
Anyway, I let these comments in the code source.