### PR TITLE
Add ak sparse

### DIFF
--- a/ak/__init__.py
+++ b/ak/__init__.py
@@ -9,3 +9,4 @@ from . import ak_other
 from . import ak_build
 from . import ak_migrate
 from . import ak_suggest
+from . import ak_sparse

--- a/ak/ak_sparse.py
+++ b/ak/ak_sparse.py
@@ -1,0 +1,69 @@
+"""AK."""
+import logging
+from plumbum import cli, local
+from plumbum.cmd import (mkdir, find, ln, git)
+from plumbum.commands.modifiers import FG, TF
+from plumbum.commands.processes import ProcessExecutionError
+import os
+import yaml
+
+from .ak_build import SPEC_YAML, get_repo_key_from_spec
+
+from .ak_sub import AkSub, Ak
+
+@Ak.subcommand("sparse")
+class AkSparse(AkSub):
+    "git sparse-checkout with modules"
+
+    disable = cli.Flag(
+        '--disable', help="disable sparse-checkout", group="IO")
+    config = cli.SwitchAttr(
+        ["c", "config"], default=SPEC_YAML, help="Config file", group="IO")
+    directory = cli.SwitchAttr(
+        ["d", "directory"], group="IO",
+        help="Only work in specified directory")
+    
+    def _generate_sparse_checkout(self, config):
+        "'Hide' modules, folder"
+        # Do we still need the links when we are using sparse-checkout ?
+        # yes, a single dir for addons_path is prefable
+        # Plus we don't break compat with "old" version of git for now.
+        spec = yaml.load(open(config).read(), Loader=yaml.FullLoader)
+        for key, repo in spec.items():
+            if self.directory and self.directory != key:
+                continue
+            modules = repo.pop('modules', False)
+            if modules:
+                self._set_sparse_checkout(key, modules)
+
+    def _set_sparse_checkout(self, key, paths):
+        repo_path = get_repo_key_from_spec(key)
+        is_new = False
+        if not local.path(repo_path).exists():
+            # init with no checkout
+            # allows to run this cmde before the git clones
+            # TODO: test with partial-clones
+            # when they will be available on github
+            local.path(repo_path).mkdir()
+            is_new = True
+        with local.cwd(repo_path):
+            if is_new:
+                git['init']()
+            if key == 'odoo':
+                directories = [
+                    dir.name for dir in local.path().list()
+                    if dir.isdir() and dir.name[0] != '.' and dir.name != 'addons'
+                    # remove files, hiddens (.git), addons
+                ]
+                paths = ['addons/%s' % path for path in paths]
+                paths += directories
+
+            git['sparse-checkout', 'init', '--cone']()
+            if self.disable:
+               git['sparse-checkout', 'disable']()
+            else:
+               git['sparse-checkout', "set", paths]()
+    
+    def main(self, *args):
+        config_file = self.config
+        self._generate_sparse_checkout(config_file)


### PR DESCRIPTION
Integrate `git sparse-checkout` in ak.
Needs  recent git version.

Usage:

```yml
# spec.yaml
server-tools:
    modules:
        - module_auto_update
        - sentry
        - base_exception
        - base_jsonify
        - onchange_helper
        - base_view_inheritance_extension
    src: https://github.com/OCA/server-tools 12.0
```

```sh
$ ak sparse
```
There wil be only the 6  directories in server-tools folder.

`ak sparse -d server-tools` for specific directory.

`ak sparse --disable` to reset and have all directories back.