### PR TITLE
Remove pathlib from requirements

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -2,5 +2,4 @@ plumbum >= 1.6.7
 git-aggregator >= 1.6.0
 kaptan >= 0.5.12
 PyYAML >= 5.1
-pathlib
 requests


### PR DESCRIPTION
Pathlib is part of the python standard library since python 3.4 but this lib breaks in python 3.10.

Ah yes and it's not used at all in ak :)