### PR TITLE
FIX import-metadata for python 3.10

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -3,3 +3,4 @@ git-aggregator >= 1.6.0
 kaptan >= 0.5.12
 PyYAML >= 5.1
 requests
+importlib-metadata; python_version >= '3.10'


### PR DESCRIPTION
Make ak compatible with python 3.10

Since python 3.10

https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata

we need to install this dependency importlib.metadata

Many other app are impacted 
https://www.google.com/search?q=importlib.metadata.PackageNotFoundError%3A+No+package+metadata+was+found+for