### PR TITLE
Ak sparse fix empty

### DIFF
--- a/ak/ak_sparse.py
+++ b/ak/ak_sparse.py
@@ -38,17 +38,12 @@ class AkSparse(AkSub):
 
     def _set_sparse_checkout(self, key, paths):
         repo_path = get_repo_key_from_spec(key)
-        is_new = False
-        if not local.path(repo_path).exists():
-            # init with no checkout
-            # allows to run this cmde before the git clones
-            # TODO: test with partial-clones
-            # when they will be available on github
-            local.path(repo_path).mkdir()
-            is_new = True
+        if not local.path(repo_path + "/.git").exists():
+            # directory do not exist
+            # or is not managed by git
+            # do nothing
+            return
         with local.cwd(repo_path):
-            if is_new:
-                git['init']()
             if key == 'odoo':
                 directories = [
                     dir.name for dir in local.path().list()

--- a/ak/ak_sparse.py
+++ b/ak/ak_sparse.py
@@ -53,7 +53,6 @@ class AkSparse(AkSub):
                 paths = ['addons/%s' % path for path in paths]
                 paths += directories
 
-            git['sparse-checkout', 'init', '--cone']()
             if self.disable:
                git['sparse-checkout', 'disable']()
             else:


### PR DESCRIPTION
sparse checkout only on git managed directories

and remove deprecated init command
`Deprecated command that behaves like set with no specified paths. May be removed in the future.`
https://git-scm.com/docs/git-sparse-checkout#Documentation/git-sparse-checkout.txt-eminitem