### PR TITLE
remove systematic fetch_all

### DIFF
--- a/ak/ak_build.py
+++ b/ak/ak_build.py
@@ -101,8 +101,6 @@ class AkBuild(AkSub):
             repo.pop('modules', None)
             if not repo.get('target'):
                 repo['target'] = '%s merged' % list(repo['remotes'].keys())[0]
-            if not 'fetch_all' in repo:
-                repo['fetch_all'] = True
             if frozen:
                 merges = repo.get('merges', [])
                 for index, merge in enumerate(merges):
@@ -136,8 +134,6 @@ class AkBuild(AkSub):
             depth = repo.get('depth')
             if depth:
                 logger.warning('Depth is deprecated. Remove it from your spec.yml')
-            if commit:
-                repo_dict['fetch_all'] = True
             return repo_dict
 
     def _generate_repo_yaml(self, config, frozen):


### PR DESCRIPTION
it was introduced in a time when we add a big depth in  `git clone` and hope to find a common ancestor

now with recent git version and partial clones and stuff, it seems counter productive to put this fetch_all: slower, .git takes 7Gb instead of 2 and in some occasions it never finish.

If you really need it, you can put it in spec.yaml and it will continue to work. Again this commit, just stop to silently add the fetch_all in all cases.