### PR TITLE
ak sparse: keep all dirs appart addons

### DIFF
--- a/ak/ak_sparse.py
+++ b/ak/ak_sparse.py
@@ -49,7 +49,7 @@ class AkSparse(AkSub):
                     git["ls-tree"]["-d"]["--name-only"]["HEAD"]
                 )
 
-                # ls-files gives us all the files
+                # ls-tree gives us all the files
                 directories = cmd().splitlines()
                 paths = ["addons/%s" % path for path in paths]
                 paths += directories


### PR DESCRIPTION
for odoo (src), we need to keep all the dirs and exclude ./addons/ the previous implementation was doing a `ls`. so it was not working if src was initialized with `git clone --filter:blob=null` because ls was returning nothing.

This implementation asks git to list all the dirs expected in .

also run a linter on the file